### PR TITLE
fix podspec

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author       = "Naoufal Kadhom"
   s.platform     = :ios, "7.0"
   s.source       = { :git => giturl + ".git", :tag => version }
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "**/*.{h,m}"
   s.requires_arc = true
 
 

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0-rc.3",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
There are .h/.m files in subdirectories that weren't currently being
considered when the package is installed as a pod. This fixes it by
making them accessible.